### PR TITLE
9a7501722d8ff01342ba26a842c4e6e1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Asynchronous Amphor vaults
+
 
 **This repository implements the ERC-7540 standard, it should so be considered as a draft since the standard is still in review state.**
 


### PR DESCRIPTION
Removed the title for Asynchronous Amphor vaults from README.